### PR TITLE
Fixes link to hideOn option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Options are set as attributes on the tooltip/popover components. Current tooltip
 - [duration](#duration)
 - [effect](#effect)
 - [event](#event)
-- [hideOn](#hideOn)
+- [hideOn](#hide-on)
 - [keepInWindow](#keep-in-window)
 - [side](#side)
 - [showOn](#show-on)


### PR DESCRIPTION
Just looking through the readme and noticed a broken link.

The link given in the readme is: https://github.com/sir-dunxalot/ember-tooltips#hideOn
But the actual anchor is: https://github.com/sir-dunxalot/ember-tooltips#hide-on

Thanks!